### PR TITLE
Adjust ocs repo url

### DIFF
--- a/smb.repos
+++ b/smb.repos
@@ -3,10 +3,10 @@ repositories:
     type: git
     url: https://bitbucket.org/leggedrobotics/compslam_rss.git
     version: master
-  ocs2_dev:
+  ocs2:
     type: git
-    url: https://bitbucket.org/leggedrobotics/ocs2.git
-    version: 067733f104eca119237c88981c6aed3720f981a8
+    url: https://github.com/leggedrobotics/ocs2.git
+    version: 7c3d33fa5633cc32d54123605cb2db7f341ac138
   smb_common:
     type: git
     url: https://github.com/ETHZ-RobotX/smb_common.git


### PR DESCRIPTION
Since release of new OCS version, the OCS2 dep is broken. Switching remote of OCS2 to github.com  and moving back 1 commit in the history, since the currently used one is not available on the new remote.