### PR TITLE
Fix mapping due to breaking changes in O3D

### DIFF
--- a/smb.repos
+++ b/smb.repos
@@ -62,7 +62,7 @@ repositories:
   slam/open3d_slam:
     type: git
     url: https://github.com/leggedrobotics/open3d_slam.git
-    version: master
+    version: 97609e36984665340fd7749762bcf65a91071bf2
   ui/multimaster_fkie:
     type: git
     url: https://github.com/ETHZ-RobotX/multimaster_fkie


### PR DESCRIPTION
The interface of `open3d_slam` was changed in a non-backwards compatible way.
This would break mapping during runtime on all new SMB/sim installations that pull via vcs.

@mantelt The easiest fix for me was to pin the last working RSS version. We could also migrate our rslidar .yaml files to the new .lua format, but it is not battle-tested on our platform and unclear if there are further changes required.